### PR TITLE
Feature: thermostat heating mode

### DIFF
--- a/.homeycompose/capabilities/mode.json
+++ b/.homeycompose/capabilities/mode.json
@@ -1,10 +1,33 @@
 {
-    "type": "string",
+    "type": "enum",
     "title": {
         "en": "Mode",
         "nl": "Modus"
     },
-    "uiComponent": "sensor",
+    "uiComponent": "picker",
     "getable": true,
-    "setable": false
+    "setable": true,
+    "values": [
+        {
+            "id": "off",
+            "title": {
+                "en": "Off (anti-frost)",
+                "nl": "Uit (anti-vorst)"
+            }
+        },
+        {
+            "id": "auto",
+            "title": {
+                "en": "Auto (schedule)",
+                "nl": "Automatisch (schema)"
+            }
+        },
+        {
+            "id": "manual",
+            "title": {
+                "en": "Manual",
+                "nl": "Handmatig"
+            }
+        }
+    ]
 }

--- a/app.json
+++ b/app.json
@@ -149,14 +149,37 @@
       "insights": true
     },
     "mode": {
-      "type": "string",
+      "type": "enum",
       "title": {
         "en": "Mode",
         "nl": "Modus"
       },
-      "uiComponent": "sensor",
+      "uiComponent": "picker",
       "getable": true,
-      "setable": false
+      "setable": true,
+      "values": [
+        {
+          "id": "off",
+          "title": {
+            "en": "Off (anti-frost)",
+            "nl": "Uit (anti-vorst)"
+          }
+        },
+        {
+          "id": "auto",
+          "title": {
+            "en": "Auto (schedule)",
+            "nl": "Automatisch (schema)"
+          }
+        },
+        {
+          "id": "manual",
+          "title": {
+            "en": "Manual",
+            "nl": "Handmatig"
+          }
+        }
+      ]
     },
     "target_temperature_water": {
       "type": "number",

--- a/drivers/remeha/device.ts
+++ b/drivers/remeha/device.ts
@@ -51,6 +51,7 @@ class RemehaThermostatDevice extends Device {
             await this.addCapability('measure_pressure')
             await this.addCapability('alarm_water')
             await this.addCapability('mode')
+            this.registerCapabilityListener('mode', this._setMode.bind(this))
 
             // optional capabilities
             await this._addOrRemoveCapability('measure_temperature_water', capabilities.hotWaterZone)
@@ -85,6 +86,7 @@ class RemehaThermostatDevice extends Device {
             this._setOptionalCapabilityValue('target_temperature_water', data.targetWaterTemperature)
             this._setOptionalCapabilityValue('fireplace_mode', data.fireplaceMode)
         } catch (error) {
+            console.log(error)
             this.setUnavailable('Could not find thermostat data')
         }
 
@@ -123,6 +125,18 @@ class RemehaThermostatDevice extends Device {
         }
     }
 
+    private async _setMode(value: string): Promise<void> {
+        await this._refreshAccessToken()
+        if (!this._client) return this.setUnavailable('No Remeha Home client')
+        const { id } = this.getData()
+
+        try {
+            await this._client.setMode(id, value)
+        } catch (error) {
+            this.setUnavailable('Could not set operating mode')
+        }
+    }
+
     private async _setFireplaceMode(value: boolean): Promise<void> {
         await this._refreshAccessToken()
         if (!this._client) return this.setUnavailable('No Remeha Home client')
@@ -133,10 +147,6 @@ class RemehaThermostatDevice extends Device {
         } catch (error) {
             this.setUnavailable('Could not set fireplace mode')
         }
-    }
-
-    private async _setTargetWaterTemperature(value: number): Promise<void> {
-        // TODO
     }
 
     private async _refreshAccessToken(): Promise<void> {

--- a/drivers/remeha/device.ts
+++ b/drivers/remeha/device.ts
@@ -86,7 +86,6 @@ class RemehaThermostatDevice extends Device {
             this._setOptionalCapabilityValue('target_temperature_water', data.targetWaterTemperature)
             this._setOptionalCapabilityValue('fireplace_mode', data.fireplaceMode)
         } catch (error) {
-            console.log(error)
             this.setUnavailable('Could not find thermostat data')
         }
 

--- a/lib/RemehaMobileApi.ts
+++ b/lib/RemehaMobileApi.ts
@@ -4,6 +4,7 @@ export type DeviceCapabilities = {
     fireplaceMode: boolean
     outdoorTemperature: boolean
     hotWaterZone: boolean
+    multiSchedule: boolean
 }
 
 export type DeviceData = {
@@ -18,6 +19,7 @@ export type DeviceData = {
     waterTemperature?: number
     targetWaterTemperature?: number
     fireplaceMode?: boolean
+    heatingProgramId?: number
 }
 
 type ResponseClimateZone = {
@@ -28,6 +30,7 @@ type ResponseClimateZone = {
     zoneMode: string
     capabilityFirePlaceMode: boolean
     firePlaceModeActive?: boolean
+    activeHeatingClimateTimeProgramNumber?: number
 }
 
 type ResponseHotWaterZone = {
@@ -44,6 +47,7 @@ type ResponseAppliance = {
     waterPressureOK: boolean
     capabilityOutdoorTemperature: boolean
     outdoorTemperature?: number
+    capabilityMultiSchedule: boolean
 }
 
 type DashboardResponse = {
@@ -89,16 +93,35 @@ export class RemehaMobileApi {
             fireplaceMode: appliance.climateZones[0].capabilityFirePlaceMode,
             outdoorTemperature: appliance.capabilityOutdoorTemperature,
             hotWaterZone: appliance.hotWaterZones.length > 0,
+            multiSchedule: appliance.capabilityMultiSchedule,
         }
     }
 
     public async setTargetTemperature(climateZoneID: string, roomTemperatureSetPoint: number): Promise<void> {
         const device = await this.device(climateZoneID)
         if (!device) return
-        if (device.mode == "Manual") {
+
+        if (device.mode == 'manual') {
             await this._call(`/climate-zones/${climateZoneID}/modes/manual`, 'POST', { roomTemperatureSetPoint })
         } else {
             await this._call(`/climate-zones/${climateZoneID}/modes/temporary-override`, 'POST', { roomTemperatureSetPoint })
+        }
+    }
+
+    public async setMode(climateZoneID: string, mode: string): Promise<void> {
+        const capabilities = await this.capabilities(climateZoneID)
+        if (!capabilities) return
+        const device = await this.device(climateZoneID)
+        if (!device) return
+
+        if (mode == 'manual') {
+            const roomTemperatureSetPoint = device.targetTemperature
+            await this._call(`/climate-zones/${climateZoneID}/modes/manual`, 'POST', { roomTemperatureSetPoint })
+        } else if (mode == 'auto') {
+            const heatingProgramId = capabilities.multiSchedule && device.heatingProgramId ? device.heatingProgramId : 1
+            await this._call(`/climate-zones/${climateZoneID}/modes/schedule`, 'POST', { heatingProgramId })
+        } else if (mode == 'off') {
+            await this._call(`/climate-zones/${climateZoneID}/modes/anti-frost`, 'POST')
         }
     }
 
@@ -139,11 +162,12 @@ export class RemehaMobileApi {
         const deviceData: DeviceData = {
             id: appliance.climateZones[0].climateZoneId,
             name: appliance.climateZones[0].name,
-            mode: appliance.climateZones[0].zoneMode,
+            mode: RemehaMobileApi._mapResponseModeToHomeyMode(appliance.climateZones[0].zoneMode),
             temperature: appliance.climateZones[0].roomTemperature,
             targetTemperature: appliance.climateZones[0].setPoint,
             waterPressure: appliance.waterPressure,
             waterPressureOK: appliance.waterPressureOK,
+            heatingProgramId: appliance.climateZones[0].activeHeatingClimateTimeProgramNumber,
         }
 
         // not every installation supports outdoor temperature
@@ -156,12 +180,22 @@ export class RemehaMobileApi {
             deviceData.fireplaceMode = appliance.climateZones[0].firePlaceModeActive
         }
 
-        // not every installation has a hot water zone, for example in Hybrid heat pumps
+        // not every installation has a hot water zone, for example in hybrid heat pumps
         if (appliance.hotWaterZones.length > 0) {
             deviceData.waterTemperature = appliance.hotWaterZones[0].dhwTemperature
             deviceData.targetWaterTemperature = appliance.hotWaterZones[0].targetSetpoint
         }
 
         return deviceData
+    }
+
+    private static _mapResponseModeToHomeyMode(mode: string): string {
+        switch (mode) {
+            case 'Manual': return 'manual'
+            case 'TemporaryOverride': return 'manual'
+            case 'Scheduling': return 'auto'
+            case 'Off': return 'off'
+            default: return 'off'
+        }
     }
 }

--- a/lib/RemehaMobileApi.ts
+++ b/lib/RemehaMobileApi.ts
@@ -194,7 +194,7 @@ export class RemehaMobileApi {
             case 'Manual': return 'manual'
             case 'TemporaryOverride': return 'manual'
             case 'Scheduling': return 'auto'
-            case 'Off': return 'off'
+            case 'FrostProtection': return 'off'
             default: return 'off'
         }
     }


### PR DESCRIPTION
This PR implements a picker UI for the thermostat heating mode. This was required in #3. The Remeha API does not allow switching between heating and/or cooling mode, so the current implementation only supports auto (active schedule), manual, or off (anti-frost). In a future PR, I will also implement the ability to select the active schedule in case multiple schedules are supported and configured.